### PR TITLE
Fix mysql reserved `key` keyword usage

### DIFF
--- a/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/Rate.java
+++ b/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/Rate.java
@@ -20,6 +20,7 @@ import com.fasterxml.jackson.annotation.JsonFormat;
 
 import java.util.Date;
 
+import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 
@@ -42,6 +43,7 @@ import lombok.NoArgsConstructor;
 public class Rate {
 
     @Id
+    @Column(name = "rate_key")
     private String key;
     private Long remaining;
     private Long remainingQuota;


### PR DESCRIPTION
Fixes #50 

#### Changes proposed in this pull request:
 - Add `@Column` to the `@Entity` class using a different naming for the `key` attribute.
 
