### PR TITLE
Add spring-boot-configuration-processor

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <java.version>1.8</java.version>
         <nexus-staging-maven-plugin.version>1.6.3</nexus-staging-maven-plugin.version>
         <global.version>1.4.0.RELEASE</global.version>
-        <jacoco.version>0.7.9</jacoco.version>
+        <jacoco.version>0.8.0</jacoco.version>
         <jacoco.it.execution.data.file>
             ${project.build.directory}/coverage-reports/jacoco.exec
         </jacoco.it.execution.data.file>

--- a/spring-cloud-zuul-ratelimit-core/pom.xml
+++ b/spring-cloud-zuul-ratelimit-core/pom.xml
@@ -52,6 +52,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <scope>provided</scope>


### PR DESCRIPTION
Fixes #48 

#### Changes proposed in this pull request:
 - Adds `spring-boot-configuration-processor` in order to make the [configuration meta-data](https://docs.spring.io/spring-boot/docs/current/reference/html/configuration-metadata.html) available for the end users.
 
