### PR TITLE
Next release version 2.2.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         ]]>
     </description>
     <url>https://github.com/marcosbarbero/spring-cloud-zuul-ratelimit</url>
-    <version>2.1.0.RELEASE</version>
+    <version>2.2.0.RELEASE</version>
 
     <licenses>
         <license>

--- a/spring-cloud-starter-zuul-ratelimit/pom.xml
+++ b/spring-cloud-starter-zuul-ratelimit/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-cloud-zuul-ratelimit-parent</artifactId>
         <groupId>com.marcosbarbero.cloud</groupId>
-        <version>2.1.0.RELEASE</version>
+        <version>2.2.0.RELEASE</version>
         <relativePath>..</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/spring-cloud-zuul-ratelimit-core/pom.xml
+++ b/spring-cloud-zuul-ratelimit-core/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.marcosbarbero.cloud</groupId>
         <artifactId>spring-cloud-zuul-ratelimit-parent</artifactId>
-        <version>2.1.0.RELEASE</version>
+        <version>2.2.0.RELEASE</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/spring-cloud-zuul-ratelimit-coverage/pom.xml
+++ b/spring-cloud-zuul-ratelimit-coverage/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-cloud-zuul-ratelimit-parent</artifactId>
         <groupId>com.marcosbarbero.cloud</groupId>
-        <version>2.1.0.RELEASE</version>
+        <version>2.2.0.RELEASE</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/spring-cloud-zuul-ratelimit-dependencies/pom.xml
+++ b/spring-cloud-zuul-ratelimit-dependencies/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>com.marcosbarbero.cloud</groupId>
     <artifactId>spring-cloud-zuul-ratelimit-dependencies</artifactId>
-    <version>2.1.0.RELEASE</version>
+    <version>2.2.0.RELEASE</version>
     <packaging>pom</packaging>
     <url>https://github.com/marcosbarbero/spring-cloud-zuul-ratelimit</url>
 

--- a/spring-cloud-zuul-ratelimit-tests/bucket4j-hazelcast/pom.xml
+++ b/spring-cloud-zuul-ratelimit-tests/bucket4j-hazelcast/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>spring-cloud-zuul-ratelimit-parent</artifactId>
         <groupId>com.marcosbarbero.cloud</groupId>
-        <version>2.1.0.RELEASE</version>
+        <version>2.2.0.RELEASE</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/spring-cloud-zuul-ratelimit-tests/bucket4j-ignite/pom.xml
+++ b/spring-cloud-zuul-ratelimit-tests/bucket4j-ignite/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>spring-cloud-zuul-ratelimit-parent</artifactId>
         <groupId>com.marcosbarbero.cloud</groupId>
-        <version>2.1.0.RELEASE</version>
+        <version>2.2.0.RELEASE</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/spring-cloud-zuul-ratelimit-tests/bucket4j-infinispan/pom.xml
+++ b/spring-cloud-zuul-ratelimit-tests/bucket4j-infinispan/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>spring-cloud-zuul-ratelimit-parent</artifactId>
         <groupId>com.marcosbarbero.cloud</groupId>
-        <version>2.1.0.RELEASE</version>
+        <version>2.2.0.RELEASE</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/spring-cloud-zuul-ratelimit-tests/bucket4j-jcache/pom.xml
+++ b/spring-cloud-zuul-ratelimit-tests/bucket4j-jcache/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>spring-cloud-zuul-ratelimit-parent</artifactId>
         <groupId>com.marcosbarbero.cloud</groupId>
-        <version>2.1.0.RELEASE</version>
+        <version>2.2.0.RELEASE</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/spring-cloud-zuul-ratelimit-tests/consul/pom.xml
+++ b/spring-cloud-zuul-ratelimit-tests/consul/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-cloud-zuul-ratelimit-parent</artifactId>
         <groupId>com.marcosbarbero.cloud</groupId>
-        <version>2.1.0.RELEASE</version>
+        <version>2.2.0.RELEASE</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/spring-cloud-zuul-ratelimit-tests/redis/pom.xml
+++ b/spring-cloud-zuul-ratelimit-tests/redis/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-cloud-zuul-ratelimit-parent</artifactId>
         <groupId>com.marcosbarbero.cloud</groupId>
-        <version>2.1.0.RELEASE</version>
+        <version>2.2.0.RELEASE</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 

--- a/spring-cloud-zuul-ratelimit-tests/springdata/pom.xml
+++ b/spring-cloud-zuul-ratelimit-tests/springdata/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <artifactId>spring-cloud-zuul-ratelimit-parent</artifactId>
         <groupId>com.marcosbarbero.cloud</groupId>
-        <version>2.1.0.RELEASE</version>
+        <version>2.2.0.RELEASE</version>
         <relativePath>../../pom.xml</relativePath>
     </parent>
 


### PR DESCRIPTION
@lchayoun I'm opening this PR just for a discussion about the next release version.
As we've removed the deprecated properties with #117 I think it's better if we move from `2.1.0` to `2.2.0`.

Do you agree? Any considerations?