### PR TITLE
maybe this example is more convincing

### DIFF
--- a/spring-cloud-zuul-ratelimit-tests/redis/src/main/java/com/marcosbarbero/tests/RedisApplication.java
+++ b/spring-cloud-zuul-ratelimit-tests/redis/src/main/java/com/marcosbarbero/tests/RedisApplication.java
@@ -50,5 +50,11 @@ public class RedisApplication {
             Thread.sleep(1100);
             return ResponseEntity.ok(RESPONSE_BODY);
         }
+
+        @GetMapping("/serviceF")
+        public ResponseEntity<String> serviceF() throws InterruptedException {
+            Thread.sleep(500);
+            return ResponseEntity.ok(RESPONSE_BODY);
+        }
     }
 }

--- a/spring-cloud-zuul-ratelimit-tests/redis/src/main/resources/application.yml
+++ b/spring-cloud-zuul-ratelimit-tests/redis/src/main/resources/application.yml
@@ -16,6 +16,9 @@ zuul:
     serviceE:
       path: /serviceE
       url: forward:/
+    serviceF:
+      path: /serviceF
+      url: forward:/
   ratelimit:
     enabled: true
     repository: REDIS
@@ -36,6 +39,11 @@ zuul:
           type:
             - url
       serviceE:
+        - quota: 1
+          refresh-interval: 60
+          type:
+            - origin
+      serviceF:
         - quota: 1
           refresh-interval: 60
           type:

--- a/spring-cloud-zuul-ratelimit-tests/redis/src/test/java/com/marcosbarbero/tests/it/RedisApplicationTestIT.java
+++ b/spring-cloud-zuul-ratelimit-tests/redis/src/test/java/com/marcosbarbero/tests/it/RedisApplicationTestIT.java
@@ -118,8 +118,7 @@ public class RedisApplicationTestIT {
     }
 
     /**
-     * 增加这个方法的目的就是为了证实quota是限制的指定时间内请求总时长，serviceF请求一次耗费500毫秒，两次请求则共耗费1s。
-     * 因此，第三次请求就触发了quota指定的限流规则，从而返回too many request
+     * Confirm that quota is limiting the total duration of requests
      */
     @Test
     public void testExceedingQuotaCapacityRequest2() {


### PR DESCRIPTION
I added an example to illustrate how quota is used to limit the total duration of requests.
Maybe three times more requests can explain the problem.