### PR TITLE
spring-cloud-zuul-ratelimit-141 Upgrade Bucket4J and caches versions

### DIFF
--- a/spring-cloud-zuul-ratelimit-core/pom.xml
+++ b/spring-cloud-zuul-ratelimit-core/pom.xml
@@ -21,10 +21,10 @@
 
     <properties>
         <main.basedir>${basedir}/..</main.basedir>
-        <bucket4j.version>3.1.1</bucket4j.version>
-        <hazelcast.version>3.10.5</hazelcast.version>
-        <ignite.version>2.6.0</ignite.version>
-        <infinispan.version>9.3.3.Final</infinispan.version>
+        <bucket4j.version>4.3.0</bucket4j.version>
+        <hazelcast.version>3.11</hazelcast.version>
+        <ignite.version>2.7.0</ignite.version>
+        <infinispan.version>9.4.5.Final</infinispan.version>
     </properties>
 
     <dependencies>

--- a/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/repository/bucket4j/AbstractBucket4jRateLimiter.java
+++ b/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/repository/bucket4j/AbstractBucket4jRateLimiter.java
@@ -16,21 +16,20 @@
 
 package com.marcosbarbero.cloud.autoconfigure.zuul.ratelimit.config.repository.bucket4j;
 
+import static java.util.concurrent.TimeUnit.NANOSECONDS;
+
 import com.marcosbarbero.cloud.autoconfigure.zuul.ratelimit.config.Rate;
 import com.marcosbarbero.cloud.autoconfigure.zuul.ratelimit.config.repository.AbstractCacheRateLimiter;
+import io.github.bucket4j.AbstractBucketBuilder;
 import io.github.bucket4j.Bandwidth;
 import io.github.bucket4j.Bucket;
 import io.github.bucket4j.Bucket4j;
 import io.github.bucket4j.BucketConfiguration;
-import io.github.bucket4j.ConfigurationBuilder;
 import io.github.bucket4j.ConsumptionProbe;
 import io.github.bucket4j.Extension;
 import io.github.bucket4j.grid.ProxyManager;
-
 import java.time.Duration;
 import java.util.function.Supplier;
-
-import static java.util.concurrent.TimeUnit.NANOSECONDS;
 
 /**
  * Bucket4j rate limiter configuration.
@@ -38,7 +37,7 @@ import static java.util.concurrent.TimeUnit.NANOSECONDS;
  * @author Liel Chayoun
  * @since 2018-04-06
  */
-abstract class AbstractBucket4jRateLimiter<T extends ConfigurationBuilder<T>, E extends Extension<T>> extends AbstractCacheRateLimiter {
+abstract class AbstractBucket4jRateLimiter<T extends AbstractBucketBuilder<T>, E extends Extension<T>> extends AbstractCacheRateLimiter {
 
     private final Class<E> extension;
     private ProxyManager<String> buckets;
@@ -66,9 +65,9 @@ abstract class AbstractBucket4jRateLimiter<T extends ConfigurationBuilder<T>, E 
     }
 
     private Supplier<BucketConfiguration> getBucketConfiguration(Long capacity, Long period) {
-        return () -> getExtension().builder()
+        return () -> Bucket4j.configurationBuilder()
                 .addLimit(Bandwidth.simple(capacity, Duration.ofSeconds(period)))
-                .buildConfiguration();
+                .build();
     }
 
     private void setRemaining(Rate rate, long remaining, boolean isQuota) {

--- a/spring-cloud-zuul-ratelimit-tests/bucket4j-hazelcast/pom.xml
+++ b/spring-cloud-zuul-ratelimit-tests/bucket4j-hazelcast/pom.xml
@@ -34,19 +34,19 @@
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-core</artifactId>
-            <version>3.1.1</version>
+            <version>4.3.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-jcache</artifactId>
-            <version>3.1.1</version>
+            <version>4.3.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-hazelcast</artifactId>
-            <version>3.1.1</version>
+            <version>4.3.0</version>
         </dependency>
 
         <dependency>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>3.9.3</version>
+            <version>3.11</version>
         </dependency>
     </dependencies>
 

--- a/spring-cloud-zuul-ratelimit-tests/bucket4j-ignite/pom.xml
+++ b/spring-cloud-zuul-ratelimit-tests/bucket4j-ignite/pom.xml
@@ -34,19 +34,19 @@
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-core</artifactId>
-            <version>3.1.1</version>
+            <version>4.3.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-jcache</artifactId>
-            <version>3.1.1</version>
+            <version>4.3.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-ignite</artifactId>
-            <version>3.1.1</version>
+            <version>4.3.0</version>
         </dependency>
 
         <dependency>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.apache.ignite</groupId>
             <artifactId>ignite-core</artifactId>
-            <version>[2.6,)</version>
+            <version>[2.7,)</version>
         </dependency>
     </dependencies>
 

--- a/spring-cloud-zuul-ratelimit-tests/bucket4j-infinispan/pom.xml
+++ b/spring-cloud-zuul-ratelimit-tests/bucket4j-infinispan/pom.xml
@@ -34,19 +34,19 @@
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-core</artifactId>
-            <version>3.1.1</version>
+            <version>4.3.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-jcache</artifactId>
-            <version>3.1.1</version>
+            <version>4.3.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-infinispan</artifactId>
-            <version>3.1.1</version>
+            <version>4.3.0</version>
         </dependency>
 
         <dependency>
@@ -58,13 +58,13 @@
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-core</artifactId>
-            <version>9.2.1.Final</version>
+            <version>9.4.5.Final</version>
         </dependency>
 
         <dependency>
             <groupId>org.infinispan</groupId>
             <artifactId>infinispan-commons</artifactId>
-            <version>9.2.1.Final</version>
+            <version>9.4.5.Final</version>
         </dependency>
     </dependencies>
 

--- a/spring-cloud-zuul-ratelimit-tests/bucket4j-jcache/pom.xml
+++ b/spring-cloud-zuul-ratelimit-tests/bucket4j-jcache/pom.xml
@@ -34,19 +34,19 @@
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-core</artifactId>
-            <version>3.1.1</version>
+            <version>4.3.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-jcache</artifactId>
-            <version>3.1.1</version>
+            <version>4.3.0</version>
         </dependency>
 
         <dependency>
             <groupId>com.github.vladimir-bukhtoyarov</groupId>
             <artifactId>bucket4j-ignite</artifactId>
-            <version>3.1.1</version>
+            <version>4.3.0</version>
         </dependency>
 
         <dependency>
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>org.apache.ignite</groupId>
             <artifactId>ignite-core</artifactId>
-            <version>[2.6,)</version>
+            <version>[2.7,)</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Fixes #141 

#### Changes proposed in this pull request:
 - Upgrade Bucket4J version to 4.3.0
 - Upgrade Hazelcast version to 3.11
 - Upgrade Ignite version to 2.7.0
 - Upgrade Infinispan version to 9.4.5
 
