### PR TITLE
BUG fix: quota never expire

### DIFF
--- a/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/repository/RedisRateLimiter.java
+++ b/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/repository/RedisRateLimiter.java
@@ -64,8 +64,8 @@ public class RedisRateLimiter extends AbstractCacheRateLimiter {
         Long current = 0L;
         try {
             current = redisTemplate.opsForValue().increment(key, usage);
-            // Redis returns 1 when the key is incremented for the first time, and the expiration time is set
-            if (current != null && current.equals(1L)) {
+            // Redis returns the value of key after the increment, check for the first increment, and the expiration time is set
+            if (current != null && current.equals(usage)) {
                 handleExpiration(key, refreshInterval);
             }
         } catch (RuntimeException e) {

--- a/spring-cloud-zuul-ratelimit-core/src/test/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/repository/RedisRateLimiterTest.java
+++ b/spring-cloud-zuul-ratelimit-core/src/test/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/repository/RedisRateLimiterTest.java
@@ -94,7 +94,7 @@ public class RedisRateLimiterTest extends BaseRateLimiterTest {
     @Test
     public void testConsumeExpireException() {
         ValueOperations ops = mock(ValueOperations.class);
-        when(ops.increment(anyString(), anyLong())).thenReturn(1L);
+        when(ops.increment(anyString(), anyLong())).thenReturn(0L);
         doReturn(ops).when(redisTemplate).opsForValue();
         when(redisTemplate.getExpire("key")).thenReturn(null);
         doThrow(new RuntimeException()).when(redisTemplate).expire(matches("key"), anyLong(), any());


### PR DESCRIPTION
Fixes 
 - #131 (maybe?)
 - quota never expire

#### Changes proposed in this pull request:
 - Redis returns the value of key after the increment,it's param 'usage' when the key is incremented for the first time
 - Redis returns the value of key after the increment,it's '0L'  for the test
 
