### PR TITLE
Fix 160 for version 1.7.x

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -234,6 +234,8 @@ Policy properties:
 |quota           |time of calls        |  -
 |refresh-interval|seconds              | 60
 |type            | [ORIGIN, USER, URL, ROLE] | []
+|breakOnMatch    |true/false           |false
+
 
 |===
 

--- a/README.adoc
+++ b/README.adoc
@@ -236,7 +236,6 @@ Policy properties:
 |type            | [ORIGIN, USER, URL, ROLE] | []
 |breakOnMatch    |true/false           |false
 
-
 |===
 
 == Further Customization

--- a/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/properties/RateLimitProperties.java
+++ b/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/properties/RateLimitProperties.java
@@ -88,6 +88,9 @@ public class RateLimitProperties {
 
         private Long quota;
 
+        @NotNull
+        private boolean breakOnMatch;
+
         @Valid
         @NotNull
         private List<MatchType> type = Lists.newArrayList();

--- a/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/filters/AbstractRateLimitFilter.java
+++ b/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/filters/AbstractRateLimitFilter.java
@@ -60,8 +60,8 @@ public abstract class AbstractRateLimitFilter extends ZuulFilter {
         String routeId = Optional.ofNullable(route).map(Route::getId).orElse(null);
         alreadyLimited = false;
         return properties.getPolicies(routeId).stream()
-                .filter(policy -> applyPolicy(request, route, policy))
-                .collect(Collectors.toList());
+            .filter(policy -> applyPolicy(request, route, policy))
+            .collect(Collectors.toList());
     }
 
     private boolean applyPolicy(HttpServletRequest request, Route route, Policy policy) {

--- a/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/filters/AbstractRateLimitFilter.java
+++ b/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/filters/AbstractRateLimitFilter.java
@@ -67,7 +67,7 @@ public abstract class AbstractRateLimitFilter extends ZuulFilter {
     private boolean applyPolicy(HttpServletRequest request, Route route, Policy policy) {
         List<MatchType> types = policy.getType();
         boolean tmp = alreadyLimited;
-        if(types.stream().allMatch(type -> type.apply(request, route, rateLimitUtils)))
+        if(policy.isBreakOnMatch() && types.stream().allMatch(type -> type.apply(request, route, rateLimitUtils)))
             alreadyLimited = true;
         return (types.isEmpty() || types.stream().allMatch(type -> type.apply(request, route, rateLimitUtils))) && !tmp;
     }

--- a/spring-cloud-zuul-ratelimit-tests/springdata/src/main/java/com/marcosbarbero/tests/SpringDataApplication.java
+++ b/spring-cloud-zuul-ratelimit-tests/springdata/src/main/java/com/marcosbarbero/tests/SpringDataApplication.java
@@ -51,5 +51,15 @@ public class SpringDataApplication {
             Thread.sleep(1100);
             return ResponseEntity.ok(RESPONSE_BODY);
         }
+
+        @GetMapping("/serviceF")
+        public ResponseEntity<String> serviceF() {
+            return ResponseEntity.ok(RESPONSE_BODY);
+        }
+
+        @GetMapping("/serviceG")
+        public ResponseEntity<String> serviceG() {
+            return ResponseEntity.ok(RESPONSE_BODY);
+        }
     }
 }

--- a/spring-cloud-zuul-ratelimit-tests/springdata/src/main/resources/application.yml
+++ b/spring-cloud-zuul-ratelimit-tests/springdata/src/main/resources/application.yml
@@ -64,6 +64,26 @@ zuul:
           refresh-interval: 60
           type:
             - origin
+      serviceF:
+        - limit: 2
+          refresh-interval: 60
+          type:
+            - origin=127.0.0.1
+          breakOnMatch: true
+        - limit: 1
+          refresh-interval: 60
+          type:
+            - origin
+      serviceG:
+        - limit: 2
+          refresh-interval: 60
+          type:
+            - origin=128.0.0.1
+          breakOnMatch: true
+        - limit: 1
+          refresh-interval: 60
+          type:
+            - origin
   strip-prefix: true
 
 logging:

--- a/spring-cloud-zuul-ratelimit-tests/springdata/src/test/java/com/marcosbarbero/tests/it/SpringDataApplicationTestIT.java
+++ b/spring-cloud-zuul-ratelimit-tests/springdata/src/test/java/com/marcosbarbero/tests/it/SpringDataApplicationTestIT.java
@@ -125,6 +125,34 @@ public class SpringDataApplicationTestIT {
         assertEquals(TOO_MANY_REQUESTS, response.getStatusCode());
     }
 
+    @Test
+    public void testUsingBreakOnMatchSpecificCase() {
+        ResponseEntity<String> response = this.restTemplate.getForEntity("/serviceF", String.class);
+        HttpHeaders headers = response.getHeaders();
+        String key = "rate-limit-application_serviceF_127.0.0.1";
+        assertHeaders(headers, key, true, false);
+        assertEquals(OK, response.getStatusCode());
+
+        response = this.restTemplate.getForEntity("/serviceF", String.class);
+        headers = response.getHeaders();
+        assertHeaders(headers, key, true, false);
+        assertEquals(OK, response.getStatusCode());
+    }
+
+    @Test
+    public void testUsingBreakOnMatchGeneralCase() {
+        ResponseEntity<String> response = this.restTemplate.getForEntity("/serviceG", String.class);
+        HttpHeaders headers = response.getHeaders();
+        String key = "rate-limit-application_serviceG_127.0.0.1";
+        assertHeaders(headers, key, true, false);
+        assertEquals(OK, response.getStatusCode());
+
+        response = this.restTemplate.getForEntity("/serviceG", String.class);
+        headers = response.getHeaders();
+        assertHeaders(headers, key, true, false);
+        assertEquals(OK, response.getStatusCode());
+    }
+
     private void assertHeaders(HttpHeaders headers, String key, boolean nullable, boolean quotaHeaders) {
         String quota = headers.getFirst(HEADER_QUOTA + key);
         String remainingQuota = headers.getFirst(HEADER_REMAINING_QUOTA + key);


### PR DESCRIPTION
Fixes #160 

#### Changes proposed in this pull request:
 - Adds the ability to only apply one limit per request in the 1.7.x branch.
 - Also adds the variable breakOnMatch that can be set to enable to disable this change, as a default the change is be disabled.
 
