### PR TITLE
remove thread sleep in favor of await in the tests

### DIFF
--- a/spring-cloud-zuul-ratelimit-tests/springdata/pom.xml
+++ b/spring-cloud-zuul-ratelimit-tests/springdata/pom.xml
@@ -41,6 +41,13 @@
             <artifactId>h2</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.awaitility</groupId>
+            <artifactId>awaitility</artifactId>
+            <version>4.0.1</version>
+            <scope>test</scope>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/spring-cloud-zuul-ratelimit-tests/springdata/src/test/java/com/marcosbarbero/tests/it/SpringDataApplicationTestIT.java
+++ b/spring-cloud-zuul-ratelimit-tests/springdata/src/test/java/com/marcosbarbero/tests/it/SpringDataApplicationTestIT.java
@@ -5,6 +5,7 @@ import static com.marcosbarbero.cloud.autoconfigure.zuul.ratelimit.support.RateL
 import static com.marcosbarbero.cloud.autoconfigure.zuul.ratelimit.support.RateLimitConstants.HEADER_REMAINING;
 import static com.marcosbarbero.cloud.autoconfigure.zuul.ratelimit.support.RateLimitConstants.HEADER_REMAINING_QUOTA;
 import static com.marcosbarbero.cloud.autoconfigure.zuul.ratelimit.support.RateLimitConstants.HEADER_RESET;
+import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
@@ -64,7 +65,7 @@ public class SpringDataApplicationTestIT {
     }
 
     @Test
-    public void testExceedingCapacity() throws InterruptedException {
+    public void testExceedingCapacity() {
         ResponseEntity<String> response = this.restTemplate.getForEntity("/serviceB", String.class);
         HttpHeaders headers = response.getHeaders();
         String key = "rate-limit-application_serviceB_127.0.0.1";
@@ -78,12 +79,13 @@ public class SpringDataApplicationTestIT {
         assertEquals(TOO_MANY_REQUESTS, response.getStatusCode());
         assertNotEquals(SpringDataApplication.ServiceController.RESPONSE_BODY, response.getBody());
 
-        TimeUnit.SECONDS.sleep(2);
-
-        response = this.restTemplate.getForEntity("/serviceB", String.class);
-        headers = response.getHeaders();
-        assertHeaders(headers, key, false, false);
-        assertEquals(OK, response.getStatusCode());
+        await().pollDelay(2, TimeUnit.SECONDS).untilAsserted(() -> {
+            final ResponseEntity<String> responseAfterReset = this.restTemplate
+                .getForEntity("/serviceB", String.class);
+            final HttpHeaders headersAfterReset = responseAfterReset.getHeaders();
+            assertHeaders(headersAfterReset, key, false, false);
+            assertEquals(OK, responseAfterReset.getStatusCode());
+        });
     }
 
     @Test


### PR DESCRIPTION
Fixes #
Removes usage of using a thread sleep in the spring data tests in favor of using awaitility

#### Changes proposed in this pull request:
 - 
 -
 -
 
