### PR TITLE
Adding support for header in the key, can be used to support custom i…

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -8,33 +8,33 @@ Module to enable rate limit per service in Netflix Zuul.
 
 There are five built-in rate limit approaches:
 
- * Authenticated User
- ** Uses the authenticated username or 'anonymous'
- * Request Origin
- ** Uses the user origin request
- * URL
- ** Uses the request path of the downstream service
- * URL Pattern
- ** Uses the request Ant path pattern to the downstream service
- * ROLE
- ** Uses the authenticated user roles
- * Request method
- ** Uses the HTTP request method
- * Global configuration per service:
- ** This one does not validate the request Origin, Authenticated User or URI
- ** To use this approach just don't set param 'type'
+* Authenticated User
+** Uses the authenticated username or 'anonymous'
+* Request Origin
+** Uses the user origin request
+* URL
+** Uses the request path of the downstream service
+* URL Pattern
+** Uses the request Ant path pattern to the downstream service
+* ROLE
+** Uses the authenticated user roles
+* Request method
+** Uses the HTTP request method
+* Request header
+** Uses the HTTP request header
+* Global configuration per service:
+** This one does not validate the request Origin, Authenticated User or URI
+** To use this approach just don't set param 'type'
 
 [NOTE]
 ====
-It is possible to combine Authenticated User, Request Origin, URL, ROLE and Request Method just adding
-multiple values to the list
-====
+It is possible to combine Authenticated User, Request Origin, URL, ROLE and Request Method just adding multiple values to the list ====
 
 == Usage
 
 [NOTE]
 ====
-Latest version: image:https://maven-badges.herokuapp.com/maven-central/com.marcosbarbero.cloud/spring-cloud-zuul-ratelimit/badge.svg["Maven Central", link="https://maven-badges.herokuapp.com/maven-central/com.marcosbarbero.cloud/spring-cloud-zuul-ratelimit"]
+Latest version: image:https://maven-badges.herokuapp.com/maven-central/com.marcosbarbero.cloud/spring-cloud-zuul-ratelimit/badge.svg["Maven Central",link="https://maven-badges.herokuapp.com/maven-central/com.marcosbarbero.cloud/spring-cloud-zuul-ratelimit"]
 ====
 
 [NOTE]
@@ -197,6 +197,7 @@ zuul:
             - url=/api #url prefix
             - role=user
             - http_method=get #case insensitive
+            - http_header=customHeader
         - type:
             - url_pattern=/api/*/payment
 ----
@@ -234,13 +235,14 @@ zuul.ratelimit.policy-list.myServiceId[1].type[1]=origin=somemachine.com
 zuul.ratelimit.policy-list.myServiceId[1].type[2]=url_pattern=/api/*/payment
 zuul.ratelimit.policy-list.myServiceId[1].type[3]=role=user
 zuul.ratelimit.policy-list.myServiceId[1].type[4]=http_method=get
+zuul.ratelimit.policy-list.myServiceId[1].type[5]=http_header=customHeader
 ----
 
 Both 'quota' and 'refresh-interval', can be expressed with https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-conversion-duration[Spring Boot's duration formats]:
 
- * A regular long representation (using seconds as the default unit)
- * The standard ISO-8601 format used by java.time.Duration (e.g. PT30M means 30 minutes)
- * A more readable format where the value and the unit are coupled (e.g. 10s means 10 seconds)
+* A regular long representation (using seconds as the default unit)
+* The standard ISO-8601 format used by java.time.Duration (e.g. PT30M means 30 minutes)
+* A more readable format where the value and the unit are coupled (e.g. 10s means 10 seconds)
 
 == Available implementations
 
@@ -302,7 +304,7 @@ Policy properties:
 |limit           |number of calls      |  -
 |quota           |time of calls        |  -
 |refresh-interval|seconds              | 60
-|type            | [ORIGIN, USER, URL, URL_PATTERN, ROLE, HTTP_METHOD] | []
+|type            | [ORIGIN, USER, URL, URL_PATTERN, ROLE, HTTP_METHOD, HTTP_HEADER] | []
 |breakOnMatch    |true/false           |false
 
 |===

--- a/README.adoc
+++ b/README.adoc
@@ -8,27 +8,28 @@ Module to enable rate limit per service in Netflix Zuul.
 
 There are five built-in rate limit approaches:
 
-* Authenticated User
-** Uses the authenticated username or 'anonymous'
-* Request Origin
-** Uses the user origin request
-* URL
-** Uses the request path of the downstream service
-* URL Pattern
-** Uses the request Ant path pattern to the downstream service
-* ROLE
-** Uses the authenticated user roles
-* Request method
-** Uses the HTTP request method
-* Request header
-** Uses the HTTP request header
-* Global configuration per service:
-** This one does not validate the request Origin, Authenticated User or URI
-** To use this approach just don't set param 'type'
+    * Authenticated User
+    ** Uses the authenticated username or 'anonymous'
+    * Request Origin
+    ** Uses the user origin request
+    * URL
+    ** Uses the request path of the downstream service
+    * URL Pattern
+    ** Uses the request Ant path pattern to the downstream service
+    * ROLE
+    ** Uses the authenticated user roles
+    * Request method
+    ** Uses the HTTP request method
+    * Request header
+    ** Uses the HTTP request header
+    * Global configuration per service:
+    ** This one does not validate the request Origin, Authenticated User or URI
+    ** To use this approach just don't set param 'type'
 
 [NOTE]
 ====
-It is possible to combine Authenticated User, Request Origin, URL, ROLE and Request Method just adding multiple values to the list ====
+It is possible to combine Authenticated User, Request Origin, URL, ROLE and Request Method just adding multiple values to the list 
+====
 
 == Usage
 
@@ -240,9 +241,9 @@ zuul.ratelimit.policy-list.myServiceId[1].type[5]=http_header=customHeader
 
 Both 'quota' and 'refresh-interval', can be expressed with https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-external-config-conversion-duration[Spring Boot's duration formats]:
 
-* A regular long representation (using seconds as the default unit)
-* The standard ISO-8601 format used by java.time.Duration (e.g. PT30M means 30 minutes)
-* A more readable format where the value and the unit are coupled (e.g. 10s means 10 seconds)
+    * A regular long representation (using seconds as the default unit)
+    * The standard ISO-8601 format used by java.time.Duration (e.g. PT30M means 30 minutes)
+    * A more readable format where the value and the unit are coupled (e.g. 10s means 10 seconds)
 
 == Available implementations
 

--- a/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/properties/RateLimitType.java
+++ b/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/properties/RateLimitType.java
@@ -17,13 +17,12 @@
 package com.marcosbarbero.cloud.autoconfigure.zuul.ratelimit.config.properties;
 
 import com.marcosbarbero.cloud.autoconfigure.zuul.ratelimit.config.RateLimitUtils;
+import java.util.Optional;
+import javax.servlet.http.HttpServletRequest;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.net.util.SubnetUtils;
 import org.springframework.cloud.netflix.zuul.filters.Route;
 import org.springframework.util.AntPathMatcher;
-
-import javax.servlet.http.HttpServletRequest;
-import java.util.Optional;
 
 public enum RateLimitType {
     /**
@@ -144,10 +143,29 @@ public enum RateLimitType {
         public boolean isValid(String matcher) {
             return StringUtils.isNotEmpty(matcher);
         }
+    },
+
+    /**
+     * Rate limit policy considering an URL Pattern
+     */
+    HTTP_HEADER {
+        public boolean apply(HttpServletRequest request, Route route, RateLimitUtils rateLimitUtils, String matcher) {
+            return StringUtils.isNotEmpty(request.getHeader(matcher));
+        }
+
+        @Override
+        public String key(HttpServletRequest request, Route route, RateLimitUtils rateLimitUtils, String matcher) {
+            return request.getHeader(matcher);
+        }
+
+        @Override
+        public boolean isValid(String matcher) {
+            return StringUtils.isNotEmpty(matcher);
+        }
     };
 
-    public abstract boolean apply(HttpServletRequest request, Route route,
-                                  RateLimitUtils rateLimitUtils, String matcher);
+    public abstract boolean apply(HttpServletRequest request, Route route, RateLimitUtils rateLimitUtils,
+        String matcher);
 
     public abstract String key(HttpServletRequest request, Route route,
                                RateLimitUtils rateLimitUtils, String matcher);

--- a/spring-cloud-zuul-ratelimit-core/src/test/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/DefaultRateLimitKeyGeneratorTest.java
+++ b/spring-cloud-zuul-ratelimit-core/src/test/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/DefaultRateLimitKeyGeneratorTest.java
@@ -25,7 +25,7 @@ public class DefaultRateLimitKeyGeneratorTest {
     @Mock
     private HttpServletRequest httpServletRequest;
 
-    private Route route = new Route("id", "/**", null, "/id", null, Collections.emptySet());
+    private final Route route = new Route("id", "/**", null, "/id", null, Collections.emptySet());
     private RateLimitProperties properties;
 
     @BeforeEach
@@ -176,5 +176,23 @@ public class DefaultRateLimitKeyGeneratorTest {
         when(httpServletRequest.getMethod()).thenReturn("GET");
         String key = target.key(httpServletRequest, route, policy);
         assertThat(key).isEqualTo("key-prefix:id:http-method:GET");
+    }
+
+    @Test
+    public void testKeyHeader() {
+        Policy policy = new Policy();
+        when(httpServletRequest.getHeader("customHeader")).thenReturn("customValue");
+        String key = target.key(httpServletRequest, route, policy);
+        assertThat(key).isEqualTo("key-prefix:id");
+    }
+
+    @Test
+    public void testKeyHeaderWithMatcher() {
+        Policy policy = new Policy();
+        String headerName = "customHeader";
+        policy.getType().add(new MatchType(RateLimitType.HTTP_HEADER, headerName));
+        when(httpServletRequest.getHeader(headerName)).thenReturn("customValue");
+        String key = target.key(httpServletRequest, route, policy);
+        assertThat(key).isEqualTo("key-prefix:id:customValue:customHeader");
     }
 }

--- a/spring-cloud-zuul-ratelimit-core/src/test/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/properties/RateLimitTypeTest.java
+++ b/spring-cloud-zuul-ratelimit-core/src/test/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/properties/RateLimitTypeTest.java
@@ -1,25 +1,24 @@
 package com.marcosbarbero.cloud.autoconfigure.zuul.ratelimit.config.properties;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.when;
+
 import com.marcosbarbero.cloud.autoconfigure.zuul.ratelimit.support.DefaultRateLimitUtils;
+import java.util.Collections;
+import java.util.concurrent.ThreadLocalRandom;
+import javax.servlet.http.HttpServletRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.cloud.netflix.zuul.filters.Route;
 
-import javax.servlet.http.HttpServletRequest;
-import java.util.Collections;
-import java.util.concurrent.ThreadLocalRandom;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.when;
-
 public class RateLimitTypeTest {
 
     @Mock
     private HttpServletRequest httpServletRequest;
-    private Route route = new Route("servicea", "/test", "servicea", "/servicea", null, Collections.emptySet());
+    private final Route route = new Route("servicea", "/test", "servicea", "/servicea", null, Collections.emptySet());
     private DefaultRateLimitUtils rateLimitUtils;
 
     @BeforeEach
@@ -158,5 +157,29 @@ public class RateLimitTypeTest {
 
         String key = RateLimitType.HTTP_METHOD.key(httpServletRequest, route, rateLimitUtils, null);
         assertThat(key).isEqualTo("GET");
+    }
+
+    @Test
+    public void applyHeader() {
+        when(httpServletRequest.getHeader("customHeader")).thenReturn("customValue");
+
+        boolean apply = RateLimitType.HTTP_HEADER.apply(httpServletRequest, route, rateLimitUtils, "customHeader");
+        assertThat(apply).isTrue();
+    }
+
+    @Test
+    public void applyHeaderNoMatch() {
+        when(httpServletRequest.getHeader("customHeader")).thenReturn("customValue");
+
+        boolean apply = RateLimitType.HTTP_HEADER.apply(httpServletRequest, route, rateLimitUtils, "customHeader2");
+        assertThat(apply).isFalse();
+    }
+
+    @Test
+    public void keyHeader() {
+        when(httpServletRequest.getHeader("customHeader")).thenReturn("customValue");
+
+        String key = RateLimitType.HTTP_HEADER.key(httpServletRequest, route, rateLimitUtils, "customHeader");
+        assertThat(key).isEqualTo("customValue");
     }
 }

--- a/spring-cloud-zuul-ratelimit-core/src/test/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/properties/validators/PoliciesValidatorTest.java
+++ b/spring-cloud-zuul-ratelimit-core/src/test/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/properties/validators/PoliciesValidatorTest.java
@@ -131,6 +131,17 @@ public class PoliciesValidatorTest {
     }
 
     @Test
+    public void testValidOnPolicyWithLimitAndMethodWithoutMatcher() {
+        properties.setKeyPrefix("prefix");
+        Policy policy = getPolicy(1L, null);
+        policy.getType().add(new Policy.MatchType(RateLimitType.ROLE, null));
+        properties.getDefaultPolicyList().add(policy);
+        properties.getPolicyList().put("key", Lists.newArrayList(policy));
+        Set<ConstraintViolation<RateLimitProperties>> violations = validator.validate(properties);
+        assertThat(violations).hasSize(2);
+    }
+    
+    @Test
     public void testValidOnPolicyWithLimitAndHeader() {
         properties.setKeyPrefix("prefix");
         Policy policy = getPolicy(1L, null);
@@ -140,12 +151,13 @@ public class PoliciesValidatorTest {
         Set<ConstraintViolation<RateLimitProperties>> violations = validator.validate(properties);
         assertThat(violations).isEmpty();
     }
-
+    
+    
     @Test
-    public void testValidOnPolicyWithLimitAndMethodWithoutMatcher() {
+    public void testValidOnPolicyWithLimitAndHeaderWithoutMatcher() {
         properties.setKeyPrefix("prefix");
         Policy policy = getPolicy(1L, null);
-        policy.getType().add(new Policy.MatchType(RateLimitType.ROLE, null));
+        policy.getType().add(new Policy.MatchType(RateLimitType.HTTP_HEADER, null));
         properties.getDefaultPolicyList().add(policy);
         properties.getPolicyList().put("key", Lists.newArrayList(policy));
         Set<ConstraintViolation<RateLimitProperties>> violations = validator.validate(properties);

--- a/spring-cloud-zuul-ratelimit-core/src/test/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/properties/validators/PoliciesValidatorTest.java
+++ b/spring-cloud-zuul-ratelimit-core/src/test/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/properties/validators/PoliciesValidatorTest.java
@@ -1,19 +1,22 @@
 package com.marcosbarbero.cloud.autoconfigure.zuul.ratelimit.config.properties.validators;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.marcosbarbero.cloud.autoconfigure.zuul.ratelimit.config.properties.RateLimitProperties;
 import com.marcosbarbero.cloud.autoconfigure.zuul.ratelimit.config.properties.RateLimitProperties.Policy;
 import com.marcosbarbero.cloud.autoconfigure.zuul.ratelimit.config.properties.RateLimitRepository;
 import com.marcosbarbero.cloud.autoconfigure.zuul.ratelimit.config.properties.RateLimitType;
+import java.time.Duration;
+import java.util.Set;
+import javax.validation.ConstraintValidatorContext;
+import javax.validation.ConstraintViolation;
+import javax.validation.Validation;
+import javax.validation.Validator;
+import javax.validation.ValidatorFactory;
 import org.assertj.core.util.Lists;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
-
-import javax.validation.*;
-import java.time.Duration;
-import java.util.Set;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class PoliciesValidatorTest {
 
@@ -121,6 +124,17 @@ public class PoliciesValidatorTest {
         properties.setKeyPrefix("prefix");
         Policy policy = getPolicy(1L, null);
         policy.getType().add(new Policy.MatchType(RateLimitType.HTTP_METHOD, "GET"));
+        properties.getDefaultPolicyList().add(policy);
+        properties.getPolicyList().put("key", Lists.newArrayList(policy));
+        Set<ConstraintViolation<RateLimitProperties>> violations = validator.validate(properties);
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    public void testValidOnPolicyWithLimitAndHeader() {
+        properties.setKeyPrefix("prefix");
+        Policy policy = getPolicy(1L, null);
+        policy.getType().add(new Policy.MatchType(RateLimitType.HTTP_HEADER, "customHeader"));
         properties.getDefaultPolicyList().add(policy);
         properties.getPolicyList().put("key", Lists.newArrayList(policy));
         Set<ConstraintViolation<RateLimitProperties>> violations = validator.validate(properties);

--- a/spring-cloud-zuul-ratelimit-core/src/test/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/support/StringToMatchTypeConverterTest.java
+++ b/spring-cloud-zuul-ratelimit-core/src/test/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/support/StringToMatchTypeConverterTest.java
@@ -73,4 +73,12 @@ public class StringToMatchTypeConverterTest {
         assertThat(matchType.getType()).isEqualByComparingTo(RateLimitType.HTTP_METHOD);
         assertThat(matchType.getMatcher()).isEqualTo("get");
     }
+
+    @Test
+    public void testConvertStringTypeHttpHeaderWithMatcher() {
+        MatchType matchType = target.convert("http_header=customHeader");
+        assertThat(matchType).isNotNull();
+        assertThat(matchType.getType()).isEqualByComparingTo(RateLimitType.HTTP_HEADER);
+        assertThat(matchType.getMatcher()).isEqualTo("customHeader");
+    }
 }


### PR DESCRIPTION
…ntegrations (non authenticated user, internal partitioning)

#### Changes proposed in this pull request:
 - add HTTP_HEADER=<matcher> type
 
