### PR TITLE
Rollback spring boot 2.4.x to 2.3.x line

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.3.10</version>
+        <version>2.3.10.RELEASE</version>
     </parent>
 
     <groupId>com.marcosbarbero.cloud</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>2.4.4</version>
+        <version>2.3.10</version>
     </parent>
 
     <groupId>com.marcosbarbero.cloud</groupId>


### PR DESCRIPTION
Rollback spring boot version because of Spring Cloud's compatibility. [Read more](https://spring.io/projects/spring-cloud)