### PR TITLE
Related to bug no #471 as AbstractCacheRateLimiter is Impacting perfo…

### DIFF
--- a/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/repository/AbstractNonBlockCacheRateLimiter.java
+++ b/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/repository/AbstractNonBlockCacheRateLimiter.java
@@ -1,0 +1,30 @@
+package com.marcosbarbero.cloud.autoconfigure.zuul.ratelimit.config.repository;
+
+import com.marcosbarbero.cloud.autoconfigure.zuul.ratelimit.config.Rate;
+import com.marcosbarbero.cloud.autoconfigure.zuul.ratelimit.config.RateLimiter;
+import com.marcosbarbero.cloud.autoconfigure.zuul.ratelimit.config.properties.RateLimitProperties;
+
+import java.time.Duration;
+
+/**
+ * @author mohamed fawzy
+ */
+public abstract class AbstractNonBlockCacheRateLimiter implements RateLimiter {
+
+    @Override
+    public Rate consume(RateLimitProperties.Policy policy, String key, Long requestTime) {
+        final Duration refreshInterval = policy.getRefreshInterval();
+        final Long quota = policy.getQuota() != null ? policy.getQuota().toMillis() : null;
+        final Rate rate = new Rate(key, policy.getLimit(), quota, null, null);
+
+        calcRemainingLimit(policy.getLimit(), refreshInterval, requestTime, key, rate);
+        calcRemainingQuota(quota, refreshInterval, requestTime, key, rate);
+
+        return rate;
+    }
+
+    protected abstract void calcRemainingLimit(Long limit, Duration refreshInterval, Long requestTime, String key, Rate rate);
+
+    protected abstract void calcRemainingQuota(Long quota, Duration refreshInterval, Long requestTime, String key, Rate rate);
+}
+

--- a/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/repository/RedisRateLimiter.java
+++ b/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/repository/RedisRateLimiter.java
@@ -33,7 +33,7 @@ import static java.util.concurrent.TimeUnit.SECONDS;
  * @author Marcos Barbero
  * @author Liel Chayoun
  */
-public class RedisRateLimiter extends AbstractCacheRateLimiter {
+public class RedisRateLimiter extends AbstractNonBlockCacheRateLimiter {
 
     private final RateLimiterErrorHandler rateLimiterErrorHandler;
     private final StringRedisTemplate redisTemplate;


### PR DESCRIPTION
Related to bug no #471 as AbstractCacheRateLimiter is Impacting performance "in case of redis" because of synchronized keyword , as Redis is single threaded and can maintain synchronization on his own , no need for extra synchronization
Fixes #

suggested fix to introduce new abstract class "AbstractNonBlockCacheRateLimiter" to handle RedisRateLimiter