### PR TITLE
Rate limit policy considering the value of header

### DIFF
--- a/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/properties/RateLimitType.java
+++ b/spring-cloud-zuul-ratelimit-core/src/main/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/properties/RateLimitType.java
@@ -198,6 +198,10 @@ public enum RateLimitType {
             return matcher;
         }
 
+        @Override
+        public boolean isValid(String matcher) {
+            return StringUtils.isNotEmpty(matcher);
+        }
     };
 
     public abstract boolean apply(HttpServletRequest request, Route route, RateLimitUtils rateLimitUtils,

--- a/spring-cloud-zuul-ratelimit-core/src/test/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/properties/RateLimitTypeTest.java
+++ b/spring-cloud-zuul-ratelimit-core/src/test/java/com/marcosbarbero/cloud/autoconfigure/zuul/ratelimit/config/properties/RateLimitTypeTest.java
@@ -5,9 +5,11 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.when;
 
 import com.marcosbarbero.cloud.autoconfigure.zuul.ratelimit.support.DefaultRateLimitUtils;
+
 import java.util.Collections;
 import java.util.concurrent.ThreadLocalRandom;
 import javax.servlet.http.HttpServletRequest;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mock;
@@ -181,5 +183,34 @@ public class RateLimitTypeTest {
 
         String key = RateLimitType.HTTP_HEADER.key(httpServletRequest, route, rateLimitUtils, "customHeader");
         assertThat(key).isEqualTo("customValue");
+    }
+
+    @Test
+    public void applyHeaderValue() {
+        when(httpServletRequest.getHeader("token")).thenReturn("myToken");
+
+        boolean apply = RateLimitType.HTTP_HEADER_VALUE.apply(httpServletRequest, route, rateLimitUtils, "token[myToken]");
+
+        assertThat(apply).isTrue();
+    }
+
+    @Test
+    public void applyHeaderValueNoMatch() {
+        when(httpServletRequest.getHeader("token")).thenReturn("otherToken");
+        when(httpServletRequest.getHeader("otherHeader")).thenReturn(null);
+
+        boolean apply = RateLimitType.HTTP_HEADER_VALUE.apply(httpServletRequest, route, rateLimitUtils, "token[myToken]");
+        assertThat(apply).isFalse();
+
+        boolean emptyApply = RateLimitType.HTTP_HEADER_VALUE.apply(httpServletRequest, route, rateLimitUtils, "otherHeader[fake]");
+        assertThat(emptyApply).isFalse();
+    }
+
+    @Test
+    public void keyHeaderValue() {
+        when(httpServletRequest.getHeader("token")).thenReturn("myToken");
+
+        String key = RateLimitType.HTTP_HEADER_VALUE.key(httpServletRequest, route, rateLimitUtils, "token[myToken]");
+        assertThat(key).isEqualTo("token[myToken]");
     }
 }


### PR DESCRIPTION
Add a kind of rate limit policy to support matching the value of the specific header.

Although the rate limit policy of http_header has helped me solved my most problems, in some scenarios, the more specific rate limit policy is required to distinguish different value of the same header.